### PR TITLE
fix path formatting

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -18,22 +18,24 @@ function Map:init(path, fw)
 	end
 end
 
+-- https://github.com/stevedonovan/Penlight/blob/master/lua/pl/path.lua#L286
 function Map.formatPath(path)
-	local str = string.split(path, "/")
-	
-	for i, segment in pairs(str) do
-		if segment == ".." then
-			str[i]		= nil
-			str[i-1]	= nil
-		end
+	local np_gen1,np_gen2 = '[^SEP]+SEP%.%.SEP?','SEP+%.?SEP'
+	local np_pat1, np_pat2
+
+	if not np_pat1 then
+		np_pat1 = np_gen1:gsub('SEP','/')
+		np_pat2 = np_gen2:gsub('SEP','/')
 	end
-	
-	path = ""
-	for _, segment in pairs(str) do
-		path = path .. segment .. "/"
-	end
-	
-	return string.sub(path, 1, path:len()-1)
+	local k
+	repeat -- /./ -> /
+		path,k = path:gsub(np_pat2,'/')
+	until k == 0
+	repeat -- A/../ -> (empty)
+		path,k = path:gsub(np_pat1,'')
+	until k == 0
+	if path == '' then path = '.' end
+	return path
 end
 
 function Map:setTiles(index, tileset, gid)


### PR DESCRIPTION
My tiled exports reference image files located more than one directory up from the export location. 
ex: image = "../../img/tiles/BlackAndWhite.png",

Currently STI is unable to reference these images and errors out.  I nabbed this bit of code from penlight although slightly modified. STI should be able to find images located at any depth.
