### PR TITLE
Account for tilesets that do not give a tileoffset.

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -75,6 +75,13 @@ function Map:setTiles(index, tileset, gid)
 				end
 			end
 			
+			local tstox,tstoy = 0,0
+			if tileset.tileoffset then
+				tstox = tileset.tileoffset.x
+				tstoy = tileset.tileoffset.y
+			end
+
+
 			local tile = {
 				gid			= gid,
 				tileset		= index,
@@ -84,8 +91,8 @@ function Map:setTiles(index, tileset, gid)
 				sy			= 1,
 				r			= 0,
 				offset		= {
-					x = -mw + tileset.tileoffset.x,
-					y = -th + tileset.tileoffset.y,
+					x = -mw + tstox,
+					y = -th + tstoy,
 				},
 			}
 			


### PR DESCRIPTION
My test map didn't have any tile offsets, and thus was crashing:

```
Error: sti/map.lua:87: attempt to index field 'tileoffset' (a nil value)
```

This is my proposed fix. In case you want to se the relevant .lua section of my map:

``` lua
  tilesets = {
    {
      name = "isometric_grass_and_water",
      firstgid = 1,
      tilewidth = 64,
      tileheight = 64,
      spacing = 0,
      margin = 0,
      image = "isometric_grass_and_water.png",
      imagewidth = 256,
      imageheight = 384,
      properties = {},
      tiles = {}
    }
  },
```
