### PR TITLE
Multiple patches

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -521,6 +521,16 @@ function Map:removeLayer(index)
 	elseif self.layers[index] then
 		table.remove(self.layers, index)
 	end
+	
+	-- if it was a tilelayer whe have to build all collision entries again
+	if layer.type == "tilelayer" then
+		self.tileInstances	= {}
+		for _, lyr in ipairs(self.layers) do
+			if lyr.type == "tilelayer" then
+				Map:setSpriteBatches(lyr)
+			end
+		end
+	end
 end
 
 function Map:update(dt)


### PR DESCRIPTION
This pull request includes multiple patches.
- When the map has a collisionmap/objectgroup for a tile but the tile is not used, the code crashes. This is fixed now.
- Added support for drawing tiles in object layers. When layer.properties.isSolid is set (custom properties in Tiled) the layer also supports collision, given the tiles have a collisionmap/objectgroup. 
  I am new to batches and I tried to use your existing code. I used a different technique to split into multiple batches. You split into batches according to the position of the tile. I had in mind that objects could move positions in the future. 
  I did not check the orientation since I do not understand what happends there. This could be a problem.
- Apparently Tiled 0.10.0 sets the y position of an tiled object to the down left instead of the upper left corner
- The removeLayer functions was not working for me and I did not understand why you try to remove it two times.
- When removing a tilelayer we need to update the collision map and the tileInstances. It probably seldom occurs that somebody removes a tilelayer, but what's done is done ;)

I actually thought about implementing a feature that allow objects to be dynamic (dynamic position and collision). But I believe that would be a big overhead for the current purpose of this library. Though I would like to set dynamic objects layer in Tiled. My current idea is to set it in Tiled anyway, export it with STI to my code, delete it from the STI map and add custom handling for the objects.
Do you know a better approach?

It would be nice to have the docs in the source code so everyone can enhance it.

Thanks!
