### PR TITLE
issue #32

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -529,7 +529,7 @@ function Map:setSpriteBatchesForObjectLayer(layer)
 			
 			-- add the quad
 			local batch = batches[ts][bi]
-			batch:add(tile.quad, object.x, object.y)
+			batch:add(tile.quad, object.x, object.y - tile.height) -- the position is bottom left and need to be upper left
 		end
 	end
 	layer.batches = batches


### PR DESCRIPTION
Added support for drawing tiles in object layers. When layer.properties.isSolid is set (custom properties in Tiled) the layer also supports collision, given the tiles have a collisionmap/objectgroup.
I am new to batches and I tried to use your existing code. I used a different technique to split into multiple batches. You split into batches according to the position of the tile. I had in mind that objects could move positions in the future.
I did not check the orientation since I do not understand what happends there. This could be a problem.
