### PR TITLE
box2d: allow custom collision info to be stored in tile properties.

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -157,12 +157,13 @@ function Map:setTiles(index, tileset, gid)
 			local id = gid - tileset.firstgid
 			local qx = (x - 1) * tw + m + (x - 1) * s
 			local qy = (y - 1) * th + m + (y - 1) * s
-			local properties, terrain, animation
+			local properties, terrain, animation, objectGroup
 
 			for _, tile in pairs(tileset.tiles) do
 				if tile.id == id then
 					properties = tile.properties
 					animation  = tile.animation
+					objectGroup = tile.objectGroup
 					if tile.terrain then
 						terrain = {}
 						for i=1,#tile.terrain do
@@ -180,6 +181,7 @@ function Map:setTiles(index, tileset, gid)
 				properties = properties or {},
 				terrain    = terrain,
 				animation  = animation,
+				objectGroup = objectGroup,
 				frame      = 1,
 				time       = 0,
 				width      = tw,

--- a/plugins/box2d.lua
+++ b/plugins/box2d.lua
@@ -125,8 +125,8 @@ return {
 		local function getPolygonVertices(object)
 			local vertices = {}
 			for _, vertex in ipairs(object.polygon) do
-				table.insert(vertices, vertex.x)
-				table.insert(vertices, vertex.y)
+				table.insert(vertices, vertex.x + object.x)
+				table.insert(vertices, vertex.y + object.y)
 			end
 
 			return vertices
@@ -183,10 +183,10 @@ return {
 				end
 
 				o.polygon = {
-					{ x=o.x,       y=o.y       },
-					{ x=o.x + o.w, y=o.y       },
-					{ x=o.x + o.w, y=o.y + o.h },
-					{ x=o.x,       y=o.y + o.h },
+					{ x=0,   y=0       },
+					{ x=o.w, y=0       },
+					{ x=o.w, y=o.h },
+					{ x=0,   y=o.h },
 				}
 
 				for _, vertex in ipairs(o.polygon) do
@@ -217,7 +217,7 @@ return {
 					addObjectToWorld(o.shape, triangle, userdata, object)
 				end
 			elseif o.shape == "polyline" then
-				local vertices	= getPolygonVertices(o)
+				local vertices = getPolygonVertices(o)
 				addObjectToWorld(o.shape, vertices, userdata, object)
 			end
 		end
@@ -230,6 +230,9 @@ return {
 				if map.tileInstances[tile.gid] then
 					for _, instance in ipairs(map.tileInstances[tile.gid]) do
 						for _, object in ipairs(tile.objectGroup.objects) do
+							-- Offset the object by the tile's position.
+							object.x = object.x + instance.x
+							object.y = object.y + instance.y
 							calculateObjectPosition(object, instance)
 						end
 					end


### PR DESCRIPTION
This allows the user to specify "shape" and "polygon" properties in the tile
data, which will be used for creating collision shapes if box2d collision
detection is used. For example, using a shape of "polyline" and a "polygon"
property of "0,0,0,16,16,16" will create an L-shaped collision shape instead
of the default rectangle.