### PR TITLE
fix a bug on Map::addCustomLayer and Map:draw

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -782,6 +782,19 @@ function Map:update(dt)
 	end
 end
 
+local pairsByKeys = function (t)
+    local a = {}
+    for k, v in pairs(t) do
+		if type(k) == "number" then a[#a+1] = k end
+    end
+    table.sort(a)
+    local i = 0
+    return function()
+        i = i + 1
+        return a[i], t[a[i]]
+    end
+end
+
 --- Draw every Layer
 -- @return nil
 function Map:draw()
@@ -794,8 +807,8 @@ function Map:draw()
 		love.graphics.clear(r,g,b,a,self.canvas)
 	end
 
-	for k, layer in pairs(self.layers) do
-		if type(k) == "number" and layer.visible and layer.opacity > 0 then
+	for k, layer in pairsByKeys(self.layers) do
+		if layer.visible and layer.opacity > 0 then
 			self:drawLayer(layer)
 		end
 	end

--- a/map.lua
+++ b/map.lua
@@ -666,6 +666,7 @@ end
 -- @param index Draw order within Layer stack
 -- @return table Custom Layer
 function Map:addCustomLayer(name, index)
+	assert(type(name) == "string", "The type of first argument must be string")
 	local index = index or #self.layers + 1
 	local layer = {
       type       = "customlayer",
@@ -793,8 +794,8 @@ function Map:draw()
 		love.graphics.clear(r,g,b,a,self.canvas)
 	end
 
-	for _, layer in ipairs(self.layers) do
-		if layer.visible and layer.opacity > 0 then
+	for k, layer in pairs(self.layers) do
+		if type(k) == "number" and layer.visible and layer.opacity > 0 then
 			self:drawLayer(layer)
 		end
 	end

--- a/plugins/box2d.lua
+++ b/plugins/box2d.lua
@@ -148,6 +148,7 @@ return {
 			}
 
 			if o.shape == "rectangle" then
+				assert(o.w > 0 and o.h > 0, "The width and height of rectangle physics object named \" " .. object.name .. "\" both need a positive number")
 				o.r       = object.rotation or 0
 				local cos = math.cos(math.rad(o.r))
 				local sin = math.sin(math.rad(o.r))


### PR DESCRIPTION
I found that it will not call layer draw function when I use too large index call Map:addCustomLayer(name, index).
So I found It caused by Map:draw() use ipair to traverse table "layers";
So it wil not call drawLayer function while the new layer index is 100 where the map haven exist layer 1 , 2, 3.

So ,
	1. I modified function Map:addCustomLayer(name, index) to force name mush be a string because we don't need two number
	type to declare where we create the new Layer.

	2. I modified the function Map:draw() to use pair instead of ipair to traverse the layer table with a judge to against
	draw the same layer