### PR TITLE
Removed hexagonal hack

### DIFF
--- a/utils.lua
+++ b/utils.lua
@@ -23,9 +23,7 @@ return {
 	end,
 
 	-- Compensation for scale/rotation shift
-	compensate = function(tile, x, y, tw, th)
-		local tx    = x + tile.offset.x
-		local ty    = y + tile.offset.y
+	compensate = function(tile, tx, ty, tw, th)
 		local origx = tx
 		local origy = ty
 		local compx = 0


### PR DESCRIPTION
Also, tile.offset is now just a shortcut to tile.tileset.tileoffset.

The main problem was that the hexsidelength was applied to both axis, while it should only be used on the staggeraxis.