### PR TITLE
Package STI into a luarocks package

### DIFF
--- a/simple-tiled-implementation-v0.16.0.3-1.rockspec
+++ b/simple-tiled-implementation-v0.16.0.3-1.rockspec
@@ -1,0 +1,22 @@
+package = "Simple-Tiled-Implementation"
+version = "v0.16.0.3-1"
+source = {
+   url = "https://github.com/karai17/Simple-Tiled-Implementation"
+}
+description = {
+   homepage = "git+https://github.com/karai17/Simple-Tiled-Implementation",
+   license = "MIT/X11"
+}
+dependencies = {
+  "lua = 5.1" -- löve rely on luajit and thus on lua 5.1
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["sti.init"] = "sti/init.lua",
+      ["sti.utils"] = "sti/utils.lua",
+      ["sti.plugins.box2d"] = "sti/plugins/box2d.lua",
+      ["sti.plugins.bump"] = "sti/plugins/bump.lua"
+   },
+   copy_directories = {"doc", "tests"}
+}

--- a/sti/init.lua
+++ b/sti/init.lua
@@ -13,9 +13,9 @@ local STI = {
 }
 STI.__index = STI
 
-local path       = (...):gsub('%.init$', '') .. "."
-local pluginPath = string.gsub(path, "[.]", "/") .. "plugins/"
-local utils      = require(path .. "utils")
+local path       = debug.getinfo(1, "S").source:sub(2):match("(.*/)")
+local pluginPath = path .. "plugins/"
+local utils      = require("sti.utils")
 local ceil       = math.ceil
 local floor      = math.floor
 local lg         = love.graphics
@@ -107,14 +107,24 @@ function Map:init(path, plugins, ox, oy)
 	end
 end
 
+local function isFile(file )
+  local f = io.open(file, "r")
+  if f ~= nil then
+    io.close(f)
+    return true
+  else
+    return false
+  end
+end
+
 --- Load plugins
 -- @param plugins A list of plugins to load
 -- @return nil
 function Map:loadPlugins(plugins)
 	for _, plugin in ipairs(plugins) do
 		local p = pluginPath .. plugin .. ".lua"
-		if love.filesystem.isFile(p) then
-			local file = love.filesystem.load(p)(path)
+		if isFile(p) then
+			local file = loadfile(p)(path)
 			for k, func in pairs(file) do
 				if not self[k] then
 					self[k] = func

--- a/sti/plugins/box2d.lua
+++ b/sti/plugins/box2d.lua
@@ -4,8 +4,7 @@
 -- @copyright 2016
 -- @license MIT/X11
 
-local path  = ...
-local utils = require(path .. "utils")
+local utils = require("sti.utils")
 
 return {
 	box2d_LICENSE     = "MIT/X11",


### PR DESCRIPTION
## Changelog
* Create a basic rockspec file using lua 5.1
* Plugins loading now relies on io module and not on love.filesystem because plugins are in luarocks directories (default should be /usr/share/lua/5.1/sti/ ).

## Tests
I ran the unit tests with the following command `busted --lua=/usr/bin/luajit-2.0.4`, 2 tests fail but they were already failing on b9866ea.

## Package
The package is currently hosted there `https://luarocks.org/modules/orbital/simple-tiled-implementation`, feel free to host it on your own luarocks account and I'll remove mine.