### PR TITLE
Add support for tile collision objects.

### DIFF
--- a/sti/plugins/bump.lua
+++ b/sti/plugins/bump.lua
@@ -54,7 +54,7 @@ return {
 
 		for _, layer in ipairs(map.layers) do
 			-- Entire layer
-			if layer.properties.collidable == "true" then
+			if layer.properties.collidable == true then
 				if layer.type == "tilelayer" then
 					for y, tiles in ipairs(layer.data) do
 						for x, tile in pairs(tiles) do

--- a/sti/plugins/bump.lua
+++ b/sti/plugins/bump.lua
@@ -25,9 +25,28 @@ return {
 				-- Every object in every instance of a tile
 				if tile.properties and tile.properties.collidable == true and map.tileInstances[gid] then
 					for _, instance in ipairs(map.tileInstances[gid]) do
-						local t = {properties = tile.properties, x = instance.x + map.offsetx, y = instance.y + map.offsety, width = map.tilewidth, height = map.tileheight, layer = instance.layer }
-						world:add(t,  t.x,t.y, t.width,t.height)
-						table.insert(collidables,t)
+						local colBox = false
+						if tile.objectGroup and tile.objectGroup.objects then
+							for _, object in ipairs(tile.objectGroup.objects) do
+								if object.type == 'colBox' then
+									colBox = true
+									local t = {}
+									t.properties = tile.properties
+									t.x = instance.x + map.offsetx + object.x
+									t.y = instance.y + map.offsety + object.y
+									t.width = object.width
+									t.height = object.height
+									t.layer = instance.layer
+									world:add(t, t.x, t.y, object.width, object.height)
+									table.insert(collidables, t)
+								end
+							end
+						end
+						if colBox == false then
+							local t = { properties = tile.properties, x = instance.x + map.offsetx, y = instance.y + map.offsety, width = map.tilewidth, height = map.tileheight, layer = instance.layer }
+							world:add(t,  t.x,t.y, t.width,t.height)
+							table.insert(collidables,t)
+						end
 					end
 				end
 			end
@@ -35,13 +54,32 @@ return {
 
 		for _, layer in ipairs(map.layers) do
 			-- Entire layer
-			if layer.properties.collidable == true then
+			if layer.properties.collidable == "true" then
 				if layer.type == "tilelayer" then
 					for y, tiles in ipairs(layer.data) do
 						for x, tile in pairs(tiles) do
-							local t = {properties = tile.properties, x = (x - 1) * map.tilewidth + tile.offset.x + map.offsetx, y = (y - 1) * map.tileheight + tile.offset.y + map.offsety, width = tile.width, height = tile.height, layer = layer }
-							world:add(t, t.x,t.y, t.width,t.height )
-							table.insert(collidables,t)
+							local colBox = false
+							if tile.objectGroup and tile.objectGroup.objects then
+								for _, object in ipairs(tile.objectGroup.objects) do
+									if object.type == 'colBox' then
+										colBox = true
+										local t = {}
+										t.properties = tile.properties
+										t.x = ((x-1) * map.tilewidth + tile.offset.x + map.offsetx) + object.x
+										t.y = ((y-1) * map.tileheight + tile.offset.y + map.offsety) + object.y
+										t.width = object.width
+										t.height = object.height
+										t.layer = layer
+										world:add(t, t.x, t.y, object.width, object.height)
+										table.insert(collidables, t)
+									end
+								end
+							end
+							if colBox == false then
+								local t = {properties = tile.properties, x = (x - 1) * map.tilewidth + tile.offset.x + map.offsetx, y = (y - 1) * map.tileheight + tile.offset.y + map.offsety, width = tile.width, height = tile.height, layer = layer }
+								world:add(t, t.x,t.y, t.width,t.height )
+								table.insert(collidables,t)
+							end
 						end
 					end
 				elseif layer.type == "imagelayer" then


### PR DESCRIPTION
Added support for tile collision objects created by Tiled's collision editor.
Simply give each collision box the type "colBox", and the plugin will now add those collision boxes *instead* of the entire tile box. This works on both collidable layers, and individual collidable tiles. 

The purpose of this is to allow a single tile to have a collision box that is not the size of the entire tile, or to allow a tile to have multiple collision boxes. (Such is the case on a corner wall tile).

Image of the code in use:
http://i.imgur.com/AB4qulv.png

The tiles used in this map are 16x16 square tiles. But because of the collision bounding boxes, the collision boxes for the walls are 5 pixels wide, and the corner tiles are able to have two separate collision boxes.