### PR TITLE
Update parameter/comment for passing map directly

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -49,13 +49,13 @@ local function new(map, plugins, ox, oy)
 end
 
 --- Instance a new map.
--- @param path Path to the map file
+-- @param map Path to the map file or the map table itself 
 -- @param plugins A list of plugins to load
 -- @param ox Offset of map on the X axis (in pixels)
 -- @param oy Offset of map on the Y axis (in pixels)
 -- @return table The loaded Map
-function STI.__call(self, path, plugins, ox, oy)
-	return new(path, plugins, ox, oy)
+function STI.__call(self, map, plugins, ox, oy)
+	return new(map, plugins, ox, oy)
 end
 
 --- Flush image cache.


### PR DESCRIPTION
This includes the documentation for #136.

@karai17: Another option would be to name the parameter `map_or_path` or `mapOrPath` or something like that, but I wasn't sure what you would prefer, so I kept it to a single lowercase word to be consistent with the rest of the API. Let me know what you think.