### PR TITLE
Load plugins using require()

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -14,7 +14,6 @@ local STI = {
 STI.__index = STI
 
 local cwd       = (...):gsub('%.init$', '') .. "."
-local pluginDir = string.gsub(cwd, "[.]", "/") .. "plugins/"
 local utils      = require(cwd .. "utils")
 local ceil       = math.ceil
 local floor      = math.floor
@@ -121,10 +120,10 @@ end
 -- @return nil
 function Map:loadPlugins(plugins)
 	for _, plugin in ipairs(plugins) do
-		local p = pluginDir .. plugin .. ".lua"
-		if love.filesystem.isFile(p) then
-			local file = love.filesystem.load(p)(cwd)
-			for k, func in pairs(file) do
+		local pluginModulePath = cwd .. 'plugins.' .. plugin
+		local ok, pluginModule = pcall(require, pluginModulePath)
+		if ok then
+			for k, func in pairs(pluginModule) do
 				if not self[k] then
 					self[k] = func
 				end

--- a/sti/plugins/box2d.lua
+++ b/sti/plugins/box2d.lua
@@ -1,16 +1,15 @@
 --- Box2D plugin for STI
 -- @module box2d
 -- @author Landon Manning
--- @copyright 2016
+-- @copyright 2017
 -- @license MIT/X11
 
-local path  = ...
-local utils = require(path:gsub('plugins.box2d', 'utils'))
+local utils = require((...):gsub('plugins.box2d', 'utils'))
 
 return {
 	box2d_LICENSE     = "MIT/X11",
 	box2d_URL         = "https://github.com/karai17/Simple-Tiled-Implementation",
-	box2d_VERSION     = "2.3.2.4",
+	box2d_VERSION     = "2.3.2.5",
 	box2d_DESCRIPTION = "Box2D hooks for STI.",
 
 	--- Initialize Box2D physics world.

--- a/sti/plugins/box2d.lua
+++ b/sti/plugins/box2d.lua
@@ -5,7 +5,7 @@
 -- @license MIT/X11
 
 local path  = ...
-local utils = require(path .. "utils")
+local utils = require(path:gsub('plugins.box2d', 'utils'))
 
 return {
 	box2d_LICENSE     = "MIT/X11",


### PR DESCRIPTION
This change allows the user to host STI anywhere in their `package.path`.

Previously, the user could only use plugins if they required STI using a
fully-qualified path with respect to the root directory of their LÖVE project.