### PR TITLE
Fixed wrong variable when creating staggered sprite batch

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -524,7 +524,7 @@ function Map:setSpriteBatches(layer)
 							
 							if batch then
 								tab.batch = batch
-								bat.id = batch:add(tile.quad, tileX, tileY, tile.r, tile.sx, tile.sy)
+								tab.id = batch:add(tile.quad, tileX, tileY, tile.r, tile.sx, tile.sy)
 							end
 							
 							self.tileInstances[tile.gid] = self.tileInstances[tile.gid] or {}


### PR DESCRIPTION
Fixes the following error:
  sti/init.lua:527: attempt to index global 'bat' (a nil value)
Only occurred with staggered maps on the X axis.