### PR TITLE
Fix error when tx, ty not specified in box2d_draw

### DIFF
--- a/sti/plugins/box2d.lua
+++ b/sti/plugins/box2d.lua
@@ -261,7 +261,7 @@ return {
 
 		lg.push()
 		lg.scale(sx or 1, sy or sx or 1)
-		lg.translate(math.floor(tx) or 0, math.floor(ty) or 0)
+		lg.translate(math.floor(tx or 0), math.floor(ty or 0))
 
 		for _, obj in ipairs(collision) do
 			local points = {collision.body:getWorldPoints(obj.shape:getPoints())}


### PR DESCRIPTION
Fixes #158
If tx, ty is not specified, `math.floor(tx) or 0` would first attempt to get the value of math.floor(tx), which causes an error since tx is nil.
By moving or 0 inside the math.floor function, we solve the error without adding any complexity to the code.