### PR TITLE
Fix error when tx, ty not specified in bump_draw

### DIFF
--- a/sti/plugins/bump.lua
+++ b/sti/plugins/bump.lua
@@ -173,7 +173,7 @@ return {
 	bump_draw = function(map, world, tx, ty, sx, sy)
 		lg.push()
 		lg.scale(sx or 1, sy or sx or 1)
-		lg.translate(math.floor(tx) or 0, math.floor(ty) or 0)
+		lg.translate(math.floor(tx or 0), math.floor(ty or 0))
 
 		for _, collidable in pairs(map.bump_collidables) do
 			lg.rectangle("line", world:getRect(collidable))


### PR DESCRIPTION
Same issue as with https://github.com/karai17/Simple-Tiled-Implementation/commit/6e5bf81a996f0507fb7c2b28ab2a79a2a64a3c74