### PR TITLE
Add assert to file loading

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -41,7 +41,7 @@ local function new(map, plugins, ox, oy)
 		end
 
 		-- Load map
-		map = setmetatable(love.filesystem.load(map)(), Map)
+		map = setmetatable(assert(love.filesystem.load(map))(), Map)
 	end
 
 	map:init(dir, plugins, ox, oy)


### PR DESCRIPTION
Instead of spitting out a nil error, we get a nice message explaining why we couldn't load the map file