### PR TITLE
Fix base64 decoding and replace deprecated decompress functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ end
 
 ## Requirements
 
-This library recommends LÖVE 0.10 and Tiled 0.18. If you are updating from an older version of Tiled, please re-export your Lua map files.
+This library recommends LÖVE 11.0 and Tiled 0.18. If you are updating from an older version of Tiled, please re-export your Lua map files.
 
 ## License
 

--- a/sti/init.lua
+++ b/sti/init.lua
@@ -211,20 +211,20 @@ function Map:setLayer(layer, path)
 	if layer.encoding then
 		if layer.encoding == "base64" then
 			assert(require "ffi", "Compressed maps require LuaJIT FFI.\nPlease Switch your interperator to LuaJIT or your Tile Layer Format to \"CSV\".")
-			local fd  = love.filesystem.newFileData(layer.data, "data", "base64"):getString()
+			local fd = love.data.decode("string", "base64", layer.data)
 
 			if not layer.compression then
 				layer.data = utils.get_decompressed_data(fd)
 			else
-				assert(love.math.decompress, "zlib and gzip compression require LOVE 0.10.0+.\nPlease set your Tile Layer Format to \"Base64 (uncompressed)\" or \"CSV\".")
+				assert(love.data.decompress, "zlib and gzip compression require LOVE 11.0+.\nPlease set your Tile Layer Format to \"Base64 (uncompressed)\" or \"CSV\".")
 
 				if layer.compression == "zlib" then
-					local data = love.math.decompress(fd, "zlib")
+					local data = love.data.decompress("string", "zlib", fd)
 					layer.data = utils.get_decompressed_data(data)
 				end
 
 				if layer.compression == "gzip" then
-					local data = love.math.decompress(fd, "gzip")
+					local data = love.data.decompress("string", "gzip", fd)
 					layer.data = utils.get_decompressed_data(data)
 				end
 			end


### PR DESCRIPTION
A couple additional changes for LÖVE 11.0.
The previous base64 decoding broke on updating from 0.10.x to 11.0, and love.math.decompress is deprecated in favor of love.data.decompress.