### PR TITLE
Fix clobbering directory structure if several levels deep

### DIFF
--- a/sti/utils.lua
+++ b/sti/utils.lua
@@ -8,11 +8,11 @@ function utils.format_path(path)
 	local k
 
 	repeat -- /./ -> /
-		path,k = path:gsub(np_pat2,'/')
+		path,k = path:gsub(np_pat2,'/',1)
 	until k == 0
 
 	repeat -- A/../ -> (empty)
-		path,k = path:gsub(np_pat1,'')
+		path,k = path:gsub(np_pat1,'',1)
 	until k == 0
 
 	if path == '' then path = '.' end


### PR DESCRIPTION
Currently, if you have a path that looks like
```/game/mapdata/world1/../../../assets/gfx/tile01.png```
it gets turned into
```/game/mapdata/assets/gfx/tile01.png```
due to np_pat1 pattern being applied multiple times in 1 go.

Making it apply once per loop successfully produces
```/assets/gfx/tile01.png```