### PR TITLE
Patch utils.rotate_vertex()

### DIFF
--- a/sti/utils.lua
+++ b/sti/utils.lua
@@ -141,7 +141,7 @@ function utils.convert_ellipse_to_polygon(x, y, w, h, max_segments)
 	return vertices
 end
 
-function utils.rotate_vertex(map, vertex, x, y, cos, sin)
+function utils.rotate_vertex(map, vertex, x, y, cos, sin, oy)
 	if map.orientation == "isometric" then
 		x, y               = utils.convert_isometric_to_screen(map, x, y)
 		vertex.x, vertex.y = utils.convert_isometric_to_screen(map, vertex.x, vertex.y)
@@ -152,7 +152,7 @@ function utils.rotate_vertex(map, vertex, x, y, cos, sin)
 
 	return
 		x + cos * vertex.x - sin * vertex.y,
-		y + sin * vertex.x + cos * vertex.y
+		y + sin * vertex.x + cos * vertex.y - (oy or 0)
 end
 
 --- Project isometric position to cartesian position


### PR DESCRIPTION
Functions calling `rotate_vertex()` sends an additional argument `oy` to compensate for sprite height. 
This parameter is now taken into account.