### PR TITLE
fix rendering of objects from tileset tiles

### DIFF
--- a/sti/plugins/box2d.lua
+++ b/sti/plugins/box2d.lua
@@ -91,8 +91,8 @@ return {
 				properties = object.properties
 			}
 
+			o.r = object.rotation or 0
 			if o.shape == "rectangle" then
-				o.r       = object.rotation or 0
 				local cos = math.cos(math.rad(o.r))
 				local sin = math.sin(math.rad(o.r))
 				local oy  = 0
@@ -180,6 +180,7 @@ return {
 					if tile.objectGroup then
 						for _, object in ipairs(tile.objectGroup.objects) do
 							if object.properties.collidable == true then
+								object = utils.deepCopy(object)
 								object.dx = instance.x + object.x
 								object.dy = instance.y + object.y
 								calculateObjectPosition(object, instance)

--- a/sti/utils.lua
+++ b/sti/utils.lua
@@ -203,4 +203,15 @@ function utils.fix_transparent_color(tileset, path)
 	end
 end
 
+function utils.deepCopy(t)
+	local copy = {}
+	for k,v in pairs(t) do
+		if type(v) == "table" then
+			v = utils.deepCopy(v)
+		end
+		copy[k] = v
+	end
+	return copy
+end
+
 return utils


### PR DESCRIPTION
When collidable objects are defined in a tileset, their properties get used each time the tile is drawn, which causes the vertex coordinates to be incremented each time -- so only the first instance of each tile is drawn in the correct place.

Doing a deep copy of the tileset's tile object properties allows them to be correctly set each time.