### PR TITLE
Fix collision placement for map objects

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -661,7 +661,7 @@ function Map:setObjectSpriteBatches(layer)
 				layer = layer,
 				gid   = tile.gid,
 				x     = tileX,
-				y     = tileY,
+				y     = tileY - oy,
 				r     = tileR,
 				oy    = oy
 			}


### PR DESCRIPTION
If you add collision objects to a tileset using the Tiled Collision Editor and proceed to create objects in a map using the tileset, its collision objects will be misplaced in the game.

This is supposed to fix that.