### PR TITLE
fix: tileInstances positioning for inifinite maps

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -500,6 +500,9 @@ function Map:set_batches(layer, chunk)
 	end
 
 	if self.orientation == "orthogonal" or self.orientation == "isometric" then
+		local offsetX = chunk and chunk.x or 0
+		local offsetY = chunk and chunk.y or 0
+
 		local startX     = 1
 		local startY     = 1
 		local endX       = chunk and chunk.width  or layer.width
@@ -529,7 +532,7 @@ function Map:set_batches(layer, chunk)
 				end
 
 				if tile then
-					self:addNewLayerTile(layer, chunk, tile, x, y)
+					self:addNewLayerTile(layer, chunk, tile, x + offsetX, y + offsetY)
 				end
 			end
 		end
@@ -866,7 +869,7 @@ function Map:drawTileLayer(layer)
 	if layer.chunks then
 		for _, chunk in ipairs(layer.chunks) do
 			for _, batch in pairs(chunk.batches) do
-				lg.draw(batch, floor(chunk.x * self.tilewidth), floor(chunk.y * self.tileheight))
+				lg.draw(batch, 0, 0)
 			end
 		end
 


### PR DESCRIPTION
I was trying to get the box2d plugin working with an infinite map and noticed that offsets were being applied incorrectly. Traced it down to the tiles in tileInstances not having the correct positions. This hopefully fixes that by updating the instance positions and removing the offset while rendering because it's already applied.