### PR TITLE
feat: center drawing parameters

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -816,7 +816,9 @@ end
 -- @param ty Translate on Y
 -- @param sx Scale on X
 -- @param sy Scale on Y
-function Map:draw(tx, ty, sx, sy)
+-- @param cx Center on X
+-- @param cy Center on Y
+function Map:draw(tx, ty, sx, sy, cx, cy)
 	local current_canvas = lg.getCanvas()
 	lg.setCanvas(self.canvas)
 	lg.clear()
@@ -825,6 +827,7 @@ function Map:draw(tx, ty, sx, sy)
 	-- Map is translated to correct position so the right section is drawn
 	lg.push()
 	lg.origin()
+	lg.translate((cx or 0) / (sx or 1), (cy or 0) / (sy or 1))
 	lg.translate(math.floor(tx or 0), math.floor(ty or 0))
 
 	for _, layer in ipairs(self.layers) do

--- a/sti/plugins/box2d.lua
+++ b/sti/plugins/box2d.lua
@@ -281,10 +281,13 @@ return {
 	-- @param ty Translate on Y
 	-- @param sx Scale on X
 	-- @param sy Scale on Y
-	box2d_draw = function(map, tx, ty, sx, sy)
+	-- @param cx Center on X
+	-- @param cy Center on Y
+	box2d_draw = function(map, tx, ty, sx, sy, cx, cy)
 		local collision = map.box2d_collision
 
 		lg.push()
+		lg.translate(cx or 0, cy or 0)
 		lg.scale(sx or 1, sy or sx or 1)
 		lg.translate(math.floor(tx or 0), math.floor(ty or 0))
 

--- a/sti/plugins/bump.lua
+++ b/sti/plugins/bump.lua
@@ -176,8 +176,11 @@ return {
 	-- @param ty Translate on Y
 	-- @param sx Scale on X
 	-- @param sy Scale on Y
-	bump_draw = function(map, world, tx, ty, sx, sy)
+	-- @param cx Center on X
+	-- @param cy Center on Y
+	bump_draw = function(map, world, tx, ty, sx, sy, cx, cy)
 		lg.push()
+		lg.translate(cx or 0, cy or 0)
 		lg.scale(sx or 1, sy or sx or 1)
 		lg.translate(math.floor(tx or 0), math.floor(ty or 0))
 


### PR DESCRIPTION
I wanted to be able to have the scaling and positioning be based of the center of the screen instead of the top left. This could also likely be done with calculations from the library consumer, but I think this is much more friendly and is also moving towards matching up with the general structure of love2d APIs.

Speaking of matching up with the love2d APIs, I wonder if it could be worth adding in a rotation parameter into the mix as well. Open question, but I figure it might be useful for some games.