### PR TITLE
I know there has to be a better way but this works.

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -666,7 +666,9 @@ function Map:setObjectSpriteBatches(layer)
 				x     = tileX,
 				y     = tileY - oy,
 				r     = tileR,
-				oy    = oy
+				oy    = oy,
+				sx    = tile.sx * sx,
+				sy    = tile.sy * sy
 			}
 
 			self.tileInstances[tile.gid] = self.tileInstances[tile.gid] or {}
@@ -800,7 +802,7 @@ function Map:update(dt)
 			if update and self.tileInstances[tile.gid] then
 				for _, j in pairs(self.tileInstances[tile.gid]) do
 					local t = self.tiles[tonumber(tile.animation[tile.frame].tileid) + self.tilesets[tile.tileset].firstgid]
-					j.batch:set(j.id, t.quad, j.x, j.y, j.r, tile.sx, tile.sy, 0, j.oy)
+					j.batch:set(j.id, t.quad, j.x, j.y, j.r, j.sx, j.sy, 0, j.oy)
 				end
 			end
 		end


### PR DESCRIPTION


sprite batch but for now this will fix it. I am wasting another 16 bytes of
data per object/tile overall. I think that I might be able to do something
like batch[id].sx and batch[id].sy to get th metadata but that's up for
a later release once I am done with this one as I am not going to fix something
that is currently already working.

Fixes issue #241