### PR TITLE
Expose Map

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -21,6 +21,7 @@ local floor = math.floor
 local lg    = require(cwd .. "graphics")
 local Map   = {}
 Map.__index = Map
+STI.Map = Map
 
 local function new(map, plugins, ox, oy)
 	local dir = ""


### PR DESCRIPTION
This exposes Map as STI.Map. This allows the Map class to be used by client code.

For example, using [bitser](https://github.com/gvx/bitser):

    local STI = require 'sti'
    local bitser = require 'bitser'
    bitser.registerClass('STI.Map', STI.Map)
    -- Map objects can now correctly be serialized/deserialized