### PR TITLE
Fix/draw tile objects

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -381,8 +381,10 @@ function Map:setObjectCoordinates(layer)
 				vertex.y           = vertex.y + y
 				vertex.x, vertex.y = utils.rotate_vertex(self, vertex, x, y, cos, sin)
 			end
-		elseif object.shape == "rectangle" then -- a tile object
-			object.x, object.y = utils.convert_isometric_to_screen(self, object.x, object.y)
+		elseif object.shape == "rectangle" and object.gid then -- a tile object
+			if self.orientation == "isometric" then
+				object.x, object.y = utils.convert_isometric_to_screen(self, object.x, object.y)
+			end
 		end
 	end
 end

--- a/sti/init.lua
+++ b/sti/init.lua
@@ -381,6 +381,8 @@ function Map:setObjectCoordinates(layer)
 				vertex.y           = vertex.y + y
 				vertex.x, vertex.y = utils.rotate_vertex(self, vertex, x, y, cos, sin)
 			end
+		elseif object.shape == "rectangle" then -- a tile object
+			object.x, object.y = utils.convert_isometric_to_screen(self, object.x, object.y)
 		end
 	end
 end


### PR DESCRIPTION
Fix drawing tile objects in isometric projection.

Please note this is not a perfect fix, but the result is much closer to what is shown in Tiled. A small offset seems to be required perfectly position the tile objects, but as of not I'm not really sure how this offset should be calculated. Also other objects (e.g. rectangles) in object layer seem to need some small adjustments in order for them to be shown in the proper position (however this PR only focuses on tile objects in object layers in isometric projection).  