### PR TITLE
Fix lack of type for bump tiles

### DIFF
--- a/sti/plugins/bump.lua
+++ b/sti/plugins/bump.lua
@@ -54,6 +54,7 @@ return {
 								width      = map.tilewidth,
 								height     = map.tileheight,
 								layer      = instance.layer,
+								type       = tile.type,
 								properties = tile.properties
 							}
 
@@ -99,6 +100,7 @@ return {
 								width      = tile.width,
 								height     = tile.height,
 								layer      = layer,
+								type       = tile.type,
 								properties = tile.properties
 							}
 


### PR DESCRIPTION
This allows tiles imported in bump maps to also have the type property from Tiled.