### PR TITLE
Map.drawRange was made obselete but still defined.

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -81,12 +81,6 @@ function Map:init(path, plugins, ox, oy)
 	self.objects       = {}
 	self.tiles         = {}
 	self.tileInstances = {}
-	self.drawRange     = {
-		sx = 1,
-		sy = 1,
-		ex = self.width,
-		ey = self.height,
-	}
 	self.offsetx = ox or 0
 	self.offsety = oy or 0
 


### PR DESCRIPTION
Map.drawRange was made obselete in change log -> 2017-02-01: v0.18.1.0.