### PR TITLE
Use the chunk's x and y in hexagonal (staggered) orientation

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -499,9 +499,9 @@ function Map:set_batches(layer, chunk)
 		layer.batches = {}
 	end
 
+	local offsetX = chunk and chunk.x or 0
+	local offsetY = chunk and chunk.y or 0
 	if self.orientation == "orthogonal" or self.orientation == "isometric" then
-		local offsetX = chunk and chunk.x or 0
-		local offsetY = chunk and chunk.y or 0
 
 		local startX     = 1
 		local startY     = 1
@@ -549,7 +549,7 @@ function Map:set_batches(layer, chunk)
 					end
 
 					if tile then
-						self:addNewLayerTile(layer, chunk, tile, x, y)
+						self:addNewLayerTile(layer, chunk, tile, x + offsetX, y + offsetY)
 					end
 				end
 			end
@@ -579,7 +579,7 @@ function Map:set_batches(layer, chunk)
 						end
 
 						if tile then
-							self:addNewLayerTile(layer, chunk, tile, x, y)
+							self:addNewLayerTile(layer, chunk, tile, x + ofsetX, y + offsetY)
 						end
 					end
 


### PR DESCRIPTION
Attached is a zip of a love2d project which should show the problem and how I found a way to fix it in STI.

I've tried using an infinite map using a hexagonal tileset, and ended up with some tiles with negative x,y coordinates.
Using STI unmodified, this mysteriously caused the tiles with negative coordinates (which get put in a chunk with a negative x offset) to end up being drawn very far to the +x instead.

Looking at the code, this seemed to be because when using a staggered orientation, the chunk's x and y values aren't used.
This pull request makes it use those offsets in every orientation.

I'm not sure if this is the correct solution overall, just that it looks sensible and fixes the issue I found.

[tileExample.zip](https://github.com/karai17/Simple-Tiled-Implementation/files/8293121/tileExample.zip)

In the attached example, with my patch to STI, hexagonal tiles get drawn to the left of the screen (and you can scroll with the cursor keys and zoom with "=" and "-"). If you revert the latest commit in the Simple-Tiled-Implementation subdirectory, it'll draw those same tiles off to the right.