### PR TITLE
Renamed 'type' property of tiles to 'class' fpr tiles

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -213,7 +213,7 @@ function Map:setTiles(index, tileset, gid)
 			local id    = gid - tileset.firstgid
 			local quadX = (x - 1) * tileW + margin + (x - 1) * spacing
 			local quadY = (y - 1) * tileH + margin + (y - 1) * spacing
-			local type = ""
+			local class = ""
 			local properties, terrain, animation, objectGroup
 
 			for _, tile in pairs(tileset.tiles) do
@@ -221,7 +221,7 @@ function Map:setTiles(index, tileset, gid)
 					properties  = tile.properties
 					animation   = tile.animation
 					objectGroup = tile.objectGroup
-					type        = tile.type
+					class       = tile.class
 
 					if tile.terrain then
 						terrain = {}
@@ -237,7 +237,7 @@ function Map:setTiles(index, tileset, gid)
 				id          = id,
 				gid         = gid,
 				tileset     = index,
-				type        = type,
+				class       = class,
 				quad        = quad(
 					quadX,  quadY,
 					tileW,  tileH,


### PR DESCRIPTION
As per https://thorbjorn.itch.io/tiled the 'type' property was renamed to 'class', so code that explicitly used 'type' should be changed to 'class'. Layers still use the 'type' property as they did before, so they don't need to be changed. There's not much code in STI that explicitly uses 'type' for non-layers, so it's a simple change.