### PR TITLE
Support for layer tint color

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -923,7 +923,15 @@ end
 -- @param layer The Layer to draw
 function Map.drawLayer(_, layer)
 	local r,g,b,a = lg.getColor()
-	lg.setColor(r, g, b, a * layer.opacity)
+	-- if the layer has a tintcolor set
+	if layer.tintcolor then 
+		r, g, b, a = unpack(layer.tintcolor)
+		a = a or 255 -- alpha may not be specified
+		lg.setColor(r/255, g/255, b/255, a/255) -- Tiled uses 0-255
+	-- if a tintcolor is not given just use the current color
+	else
+		lg.setColor(r, g, b, a * layer.opacity)
+	end
 	layer:draw()
 	lg.setColor(r,g,b,a)
 end


### PR DESCRIPTION
Pretty much what it says on the box. Tiled has supported tint colors for each layer since 1.4. This small addition automatically renders them using lg.setColor() in Map:draw(), as long as the 'tintcolor' property is set. 