### PR TITLE
Feature imagelayer repeat

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -923,7 +923,15 @@ end
 -- @param layer The Layer to draw
 function Map.drawLayer(_, layer)
 	local r,g,b,a = lg.getColor()
-	lg.setColor(r, g, b, a * layer.opacity)
+	-- if the layer has a tintcolor set
+	if layer.tintcolor then 
+		r, g, b, a = unpack(layer.tintcolor)
+		a = a or 255 -- alpha may not be specified
+		lg.setColor(r/255, g/255, b/255, a/255) -- Tiled uses 0-255
+	-- if a tintcolor is not given just use the current color
+	else
+		lg.setColor(r, g, b, a * layer.opacity)
+	end
 	layer:draw()
 	lg.setColor(r,g,b,a)
 end

--- a/sti/init.lua
+++ b/sti/init.lua
@@ -1046,6 +1046,32 @@ function Map:drawImageLayer(layer)
 
 	if layer.image ~= "" then
 		lg.draw(layer.image, layer.x, layer.y)
+		-- we need pixel sizes for drawing
+		local imagewidth, imageheight = layer.image:getDimensions()
+		-- if we're repeating on the Y axis...
+		if layer.repeaty then
+			local x = imagewidth
+			local y = imageheight
+			while y < self.height * self.tileheight do 
+				lg.draw(layer.image, x, y)
+				-- if we are *also* repeating on X
+				if layer.repeatx then 
+					x = x + imagewidth
+					while x < self.width * self.tilewidth do 
+						lg.draw(layer.image, x, y)
+						x = x + imagewidth
+					end
+				end
+				y = y + imageheight
+			end
+		-- if we're repeating on X alone...
+		elseif layer.repeatx then
+			local x = imagewidth
+			while x < self.width * self.tilewidth do 
+				lg.draw(layer.image, x, layer.y)
+				x = x + imagewidth
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
Tiled 1.8 added support for repeating images on Image Layers in both the X and Y directions. This change applies the image repetition in drawImageLayer(). The algorithm is pretty simple and direct. It draws the images repeatedly in a loop (nested in the case of both X and Y repeating) for the size of the map. 