### PR TITLE
Feature parallax

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -897,6 +897,31 @@ function Map:draw(tx, ty, sx, sy)
 	-- Map is translated to correct position so the right section is drawn
 	lg.push()
 	lg.origin()
+	
+	--[[
+		This snippet comes from 'monolifed' on the Love2D forums,
+		however it was more or less exactly the same code I was already writing 
+		to implement the same parallax scrolling. I found his before 
+		testing and polishing mine
+		https://love2d.org/forums/viewtopic.php?p=238378#p238378
+
+		previous code commented below the new. 
+
+	]]
+
+	tx, ty = tx or 0, ty or 0
+
+	for _, layer in ipairs(self.layers) do
+		if layer.visible and layer.opacity > 0 then
+			local px, py = layer.parallaxx or 1, layer.parallaxy or 1
+			px, py = math.floor(tx * px), math.floor(ty * py)
+			lg.translate(px, py)
+			self:drawLayer(layer)
+			lg.translate(-px, -py)
+		end
+	end
+
+	--[[
 	lg.translate(math.floor(tx or 0), math.floor(ty or 0))
 
 	for _, layer in ipairs(self.layers) do
@@ -904,6 +929,7 @@ function Map:draw(tx, ty, sx, sy)
 			self:drawLayer(layer)
 		end
 	end
+	]]
 
 	lg.pop()
 

--- a/sti/init.lua
+++ b/sti/init.lua
@@ -923,7 +923,15 @@ end
 -- @param layer The Layer to draw
 function Map.drawLayer(_, layer)
 	local r,g,b,a = lg.getColor()
-	lg.setColor(r, g, b, a * layer.opacity)
+	-- if the layer has a tintcolor set
+	if layer.tintcolor then 
+		r, g, b, a = unpack(layer.tintcolor)
+		a = a or 255 -- alpha may not be specified
+		lg.setColor(r/255, g/255, b/255, a/255) -- Tiled uses 0-255
+	-- if a tintcolor is not given just use the current color
+	else
+		lg.setColor(r, g, b, a * layer.opacity)
+	end
 	layer:draw()
 	lg.setColor(r,g,b,a)
 end

--- a/sti/init.lua
+++ b/sti/init.lua
@@ -1046,6 +1046,32 @@ function Map:drawImageLayer(layer)
 
 	if layer.image ~= "" then
 		lg.draw(layer.image, layer.x, layer.y)
+		-- we need pixel sizes for drawing
+		local imagewidth, imageheight = layer.image:getDimensions()
+		-- if we're repeating on the Y axis...
+		if layer.repeaty then
+			local x = imagewidth
+			local y = imageheight
+			while y < self.height * self.tileheight do 
+				lg.draw(layer.image, x, y)
+				-- if we are *also* repeating on X
+				if layer.repeatx then 
+					x = x + imagewidth
+					while x < self.width * self.tilewidth do 
+						lg.draw(layer.image, x, y)
+						x = x + imagewidth
+					end
+				end
+				y = y + imageheight
+			end
+		-- if we're repeating on X alone...
+		elseif layer.repeatx then
+			local x = imagewidth
+			while x < self.width * self.tilewidth do 
+				lg.draw(layer.image, x, layer.y)
+				x = x + imagewidth
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
Added support for automatic parallax scrolling of layers, added in Tiled 1.5. 

While developing my own algorithm, I happened upon a thread on the Love2D forums and found a snippet by 'monolifed', which was nearly identical to my own. I tested it and it seems to work nicely.

I'm not sure how best to handle this pull request, for two reasons: this is technically not my code. I used it because it was a bit more succinct.  The other reason is that parallax backgrounds are most effective when implemented as repeating image layers. So this feature almost requires the repeating image layers feature in my other pull request. 